### PR TITLE
networking_basic: platform attribute fix.

### DIFF
--- a/networking_basic/attributes/default.rb
+++ b/networking_basic/attributes/default.rb
@@ -1,41 +1,6 @@
-default[:debian][:install_list] = [
-  'lsof',
-  'iptables',
-  'jwhois',
-  'whois',
-  'curl',
-  'wget',
-  'rsync',
-  'jnettop',
-  'nmap',
-  'traceroute',
-  'ethtool',
-  'iproute',
-  'iputils-ping',
-  'netcat-openbsd',
-  'tcptraceroute',
-  'tcputils',
-  'tcpdump',
-  'elinks',
-  'lynx'
-]
-
-default[:redhat][:install_list] = [
-  'lsof',
-  'iptables',
-  'jwhois',
-  'curl',
-  'wget',
-  'rsync',
-  'nmap',
-  'traceroute',
-  'ethtool',
-  'iproute',
-  'iputils',
-  'nc',
-  'tcptraceroute',
-  'tcputils',
-  'tcpdump',
-  'elinks',
-  'lynx'
-]
+case node['platform']
+when "debian","ubuntu"
+  default['networking']['packages'] = %w[ lsof iptables jwhois whois curl wget rsync jnettop nmap traceroute ethtool iproute iputils-ping netcat-openbsd tcptraceroute tcputils tcpdump elinks lynx ]
+when "redhat","centos","scientific","amazon"
+  default['networking']['packages'] = %w[ lsof iptables jwhois curl wget rsync nmap traceroute ethtool iproute iputils nc tcptraceroute tcputils tcpdump elinks lynx ]
+end

--- a/networking_basic/metadata.rb
+++ b/networking_basic/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "fred.the.master@gmail.com, tim.smith@webtrends.com"
 license          "Apache 2.0"
 description      "Install Basic Networking Tools and Utilities on Debian, Centos RedHat and Ubuntu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.textile'))
-version          "0.0.3"
+version          "0.0.4"
 
 %w{ ubuntu debian centos redhat }.each do |os|
   supports os

--- a/networking_basic/recipes/default.rb
+++ b/networking_basic/recipes/default.rb
@@ -4,19 +4,6 @@
 #
 #
 
-case node[:platform]
-  when "debian", "ubuntu"
-    node[:debian][:install_list].each do |pkg|
-      package pkg do
-        action :install
-        ignore_failure true
-    end
-  end
-  when "rhel", "centos"
-    node[:redhat][:install_list].each do |pkg|
-      package pkg do
-        action :install
-        ignore_failure true
-    end
-  end
+node['networking']['packages'].each do |netpkg|
+  package netpkg
 end


### PR DESCRIPTION
NOTE: networking_basic on community.opscode.com, still refers to README.rdoc, causing problems for folks trying to upload to chef-server/opscode platform

Fixed: invalid platform attribute "rhel".  Added redhat, centos, scientific, amazon
