### PR TITLE
Update metadata.rb to point to new README.md

### DIFF
--- a/networking_basic/metadata.rb
+++ b/networking_basic/metadata.rb
@@ -2,7 +2,7 @@ maintainer       "Frederico Araujo, Tim Smith"
 maintainer_email "fred.the.master@gmail.com, tim.smith@webtrends.com, atomic-penguin (Eric G. Wolfe)"
 license          "Apache 2.0"
 description      "Install Basic Networking Tools and Utilities on Debian, Centos RedHat and Ubuntu"
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.textile'))
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.0.7"
 
 %w{ ubuntu debian centos redhat }.each do |os|


### PR DESCRIPTION
Updated file to point to new README. I was doing the Learn Chef tutorial and it was throwing errors trying to find README.textile which no longer exists.
