### PR TITLE
Add name attribute to metadata.rb for networking_basic

### DIFF
--- a/networking_basic/metadata.json
+++ b/networking_basic/metadata.json
@@ -1,4 +1,5 @@
 {
+    "name": "networking_basic",
     "version": "0.0.7",
     "maintainer": "Frederico Araujo, Tim Smith, atomic-penguin (Eric G. Wolfe)",
     "replacing": {

--- a/networking_basic/metadata.rb
+++ b/networking_basic/metadata.rb
@@ -1,3 +1,4 @@
+name            "networking_basic"
 maintainer       "Frederico Araujo, Tim Smith"
 maintainer_email "fred.the.master@gmail.com, tim.smith@webtrends.com, atomic-penguin (Eric G. Wolfe)"
 license          "Apache 2.0"


### PR DESCRIPTION
This is required for this cookbook to work with chef-zero/solo.
